### PR TITLE
fix(contact): Use a window capture event listener

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -50,10 +50,8 @@
   <script>
     var submitted = false;
     var form = document.getElementById('contact-form');
-    console.debug(form ? 'form initialized' : 'form not initialized');
-    form.addEventListener('submit', function(event) {
-      console.debug('form submit event', event);
-      if (!submitted) {
+    window.addEventListener('submit', function(event) {
+      if (event.target === form && !submitted) {
         submitted = true;
         event.preventDefault();
         var xhr = new XMLHttpRequest();
@@ -69,6 +67,6 @@
       }
       form.reset();
       alert('Thank you! An Aurelia team member will be in contact with you shortly!');
-    });
+    }, true);
   </script>
 </section>


### PR DESCRIPTION
Was still having issues, only when deployed with dev tools closed. Was not registering or triggering the event listener on form.

This change uses a delegate pattern, moving the handler to the window event at the capture phase. I'm hoping that this will resolve any timing issues.